### PR TITLE
ssl wrap_socket update

### DIFF
--- a/substrata_bot_demo.py
+++ b/substrata_bot_demo.py
@@ -115,8 +115,14 @@ plain_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
 print("Connecting to server '" + server_hostname + "'...")
 
-conn = ssl.wrap_socket(plain_socket)
-conn.connect((server_hostname, 7600))
+# (pre-python 3.7)
+#conn = ssl.wrap_socket(plain_socket)
+#conn.connect((server_hostname, 7600))
+# ========================
+# https://stackoverflow.com/questions/4818280/ssl-wrap-socket-attributeerror-module-object-has-no-attribute-wrap-socket
+sslSettings = ssl.SSLContext(ssl.PROTOCOL_TLS)
+conn = sslSettings.wrap_socket(plain_socket)
+conn.connect(server_hostname,  7600)
 
 print("Connected to server '" + server_hostname + "'.")
 

--- a/substrata_chatbot_demo.py
+++ b/substrata_chatbot_demo.py
@@ -93,8 +93,14 @@ plain_socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, True)
 
 print("Connecting to server '" + server_hostname + "'...")
 
-conn = ssl.wrap_socket(plain_socket)
-conn.connect((server_hostname,  7600))
+# (pre-python 3.7)
+#conn = ssl.wrap_socket(plain_socket)
+#conn.connect((server_hostname, 7600))
+# ========================
+# https://stackoverflow.com/questions/4818280/ssl-wrap-socket-attributeerror-module-object-has-no-attribute-wrap-socket
+sslSettings = ssl.SSLContext(ssl.PROTOCOL_TLS)
+conn = sslSettings.wrap_socket(plain_socket)
+conn.connect(server_hostname,  7600) 
 
 print("Connected to server '" + server_hostname + "'.")
 


### PR DESCRIPTION
updated both demo files; changed the ssl.wrap_socket method. The old version was deprecated in python 3.7, removed in python 3.12.