### PR TITLE
bug fix, connect method

### DIFF
--- a/substrata_bot_demo.py
+++ b/substrata_bot_demo.py
@@ -122,7 +122,7 @@ print("Connecting to server '" + server_hostname + "'...")
 # https://stackoverflow.com/questions/4818280/ssl-wrap-socket-attributeerror-module-object-has-no-attribute-wrap-socket
 sslSettings = ssl.SSLContext(ssl.PROTOCOL_TLS)
 conn = sslSettings.wrap_socket(plain_socket)
-conn.connect(server_hostname,  7600)
+conn.connect((server_hostname,  7600))
 
 print("Connected to server '" + server_hostname + "'.")
 

--- a/substrata_chatbot_demo.py
+++ b/substrata_chatbot_demo.py
@@ -100,7 +100,7 @@ print("Connecting to server '" + server_hostname + "'...")
 # https://stackoverflow.com/questions/4818280/ssl-wrap-socket-attributeerror-module-object-has-no-attribute-wrap-socket
 sslSettings = ssl.SSLContext(ssl.PROTOCOL_TLS)
 conn = sslSettings.wrap_socket(plain_socket)
-conn.connect(server_hostname,  7600) 
+conn.connect((server_hostname,7600))
 
 print("Connected to server '" + server_hostname + "'.")
 


### PR DESCRIPTION
not sure why, but the double parens seemed to be unnecessary but the connect fails without them.